### PR TITLE
Add patch to fix osx-64 build errors

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -12,3 +12,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 target_platform:
 - linux-64
+zip_keys:
+- - cdt_name
+  - docker_image

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge/label/rust_dev,conda-forge
+- conda-forge
 channel_targets:
 - conda-forge main
 macos_machine:

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -45,8 +45,12 @@ fi
 if [ -z "${DOCKER_IMAGE}" ]; then
     SHYAML_INSTALLED="$(shyaml -h || echo NO)"
     if [ "${SHYAML_INSTALLED}" == "NO" ]; then
-        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
-        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Trying to parse with coreutils"
+        DOCKER_IMAGE=$(cat .ci_support/${CONFIG}.yaml | grep '^docker_image:$' -A 1 | tail -n 1 | cut -b 3-)
+        if [ "${DOCKER_IMAGE}" = "" ]; then
+            echo "No docker_image entry found in ${CONFIG}. Falling back to condaforge/linux-anvil-comp7"
+            DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+        fi
     else
         DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
     fi
@@ -64,8 +68,8 @@ fi
 
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 docker run ${DOCKER_RUN_ARGS} \
-           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z \
-           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z \
+           -v "${RECIPE_ROOT}":/home/conda/recipe_root:rw,z,delegated \
+           -v "${FEEDSTOCK_ROOT}":/home/conda/feedstock_root:rw,z,delegated \
            -e CONFIG \
            -e HOST_USER_ID \
            -e UPLOAD_PACKAGES \

--- a/recipe/c8fca6b4a02d695b1ceea39b330d4406001c03ed.patch
+++ b/recipe/c8fca6b4a02d695b1ceea39b330d4406001c03ed.patch
@@ -1,0 +1,30 @@
+From c8fca6b4a02d695b1ceea39b330d4406001c03ed Mon Sep 17 00:00:00 2001
+From: Tristan Matthews <tmatth@videolan.org>
+Date: Sat, 7 Sep 2019 00:46:59 -0400
+Subject: [PATCH] os_types: fix unsigned typedefs for MacOS
+
+This effectively reverts f8ce071e1040c766157d630d920d6165d35fe422 which was
+probably broken by 6449883ccacfee276ed9d99fa047342cdc51ab88.
+---
+ include/ogg/os_types.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/include/ogg/os_types.h b/include/ogg/os_types.h
+index eb8a322..e655a1d 100644
+--- a/include/ogg/os_types.h
++++ b/include/ogg/os_types.h
+@@ -72,11 +72,11 @@
+ 
+ #  include <sys/types.h>
+    typedef int16_t ogg_int16_t;
+-   typedef uint16_t ogg_uint16_t;
++   typedef u_int16_t ogg_uint16_t;
+    typedef int32_t ogg_int32_t;
+-   typedef uint32_t ogg_uint32_t;
++   typedef u_int32_t ogg_uint32_t;
+    typedef int64_t ogg_int64_t;
+-   typedef uint64_t ogg_uint64_t;
++   typedef u_int64_t ogg_uint64_t;
+ 
+ #elif defined(__HAIKU__)
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: http://downloads.xiph.org/releases/{{ name }}/lib{{ name }}-{{ version }}.tar.gz
   sha256: fe5670640bd49e828d64d2879c31cb4dde9758681bb664f9bdbf159a01b0c76e
+  patches:
+    - c8fca6b4a02d695b1ceea39b330d4406001c03ed.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage('libogg', max_pin='x.x') }}
 


### PR DESCRIPTION
This is the patch upstream used to fix issues with newer clang versions. For the failure see https://github.com/conda-forge/libvorbis-feedstock/pull/17 and https://github.com/conda-forge/libflac-feedstock/pull/11

Verified locally that this fixes the build issues.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
